### PR TITLE
Use Sprig templating library instead of Pongo2

### DIFF
--- a/epp.go
+++ b/epp.go
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	if *output == "" {
-		fmt.Printf(string(out))
+		fmt.Print(string(out))
 		return
 	}
 

--- a/epp/epp_test.go
+++ b/epp/epp_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-
-	"github.com/flosch/pongo2"
 )
 
 func init() {
@@ -15,7 +13,7 @@ func init() {
 }
 
 func TestEnvVariables(t *testing.T) {
-	tpl := []byte("{{ SPLIT_TEST }}: {{ KUBERNETES_ADDRESS }}")
+	tpl := []byte(`{{ env "SPLIT_TEST" }}: {{ env "KUBERNETES_ADDRESS" }}`)
 	expected := fmt.Sprintf("%s: %s", os.Getenv("SPLIT_TEST"), os.Getenv("KUBERNETES_ADDRESS"))
 
 	res, err := Parse(tpl)
@@ -31,13 +29,12 @@ func TestEnvVariables(t *testing.T) {
 
 func TestEnvIf(t *testing.T) {
 	tpl := []byte(`
-{% if FALSY %}
+{{- if env "$FALSY" }}
 I shouldn't appear
-{% endif %}
+{{- end }}
 I should!
 `)
 	expected := `
-
 I should!
 `
 
@@ -49,19 +46,5 @@ I should!
 
 	if string(res) != expected {
 		t.Errorf("bad expansion: expected '%s', got '%s'", expected, res)
-	}
-}
-
-func TestFilterBase64Encode(t *testing.T) {
-	actualResult, err := filterBase64Encode(pongo2.AsValue("Hello"), pongo2.AsValue(""))
-
-	if err != nil {
-		t.Errorf("unexpected error '%s'", err)
-	}
-
-	expectedResult := "SGVsbG8="
-
-	if actualResult.String() != expectedResult {
-		t.Errorf("Expected %s but got %s", expectedResult, actualResult)
 	}
 }


### PR DESCRIPTION
Switch from Pongo to Sprig templating library:

- more idiomatic-go template helpers

  `{{ "hello" | default "world" }}` new vs old `{{ "hello" | default:"world"  }}`

- safer usage of environment variables

  `{{ env "HELLO" }}` new vs old `{{ HELLO }}`

- uses same templating library as Helm

This is (obviously) not backward compatible, so we'll probably want to make this a pre-release for now, opting for a new major release after we're ready to ship this change.