### PR TITLE
add "include" template function

### DIFF
--- a/epp/epp.go
+++ b/epp/epp.go
@@ -10,8 +10,19 @@ import (
 // Parse parses the input and returns the output
 func Parse(input []byte) ([]byte, error) {
 	var writer bytes.Buffer
+	t := template.New("test")
 
-	tpl, err := template.New("test").Funcs(sprig.TxtFuncMap()).Parse(string(input))
+	funcMap := template.FuncMap{
+		"include": func(name string, data interface{}) (string, error) {
+			buf := bytes.NewBuffer(nil)
+			if err := t.ExecuteTemplate(buf, name, data); err != nil {
+				return "", err
+			}
+			return buf.String(), nil
+		},
+	}
+
+	tpl, err := t.Funcs(sprig.TxtFuncMap()).Funcs(funcMap).Parse(string(input))
 	if err != nil {
 		return nil, err
 	}

--- a/epp/epp_test.go
+++ b/epp/epp_test.go
@@ -48,3 +48,20 @@ I should!
 		t.Errorf("bad expansion: expected '%s', got '%s'", expected, res)
 	}
 }
+
+func TestInclude(t *testing.T) {
+	tpl := []byte(`{{ define "worldtpl" }}world{{- end }}
+hello {{ include "worldtpl" . | upper }}`)
+	expected := `
+hello WORLD`
+
+	res, err := Parse(tpl)
+
+	if err != nil {
+		t.Errorf("unexpected error '%s'", err)
+	}
+
+	if string(res) != expected {
+		t.Errorf("bad expansion: expected '%s', got '%s'", expected, res)
+	}
+}


### PR DESCRIPTION
This equals the templating function used in Helm.

It provides the same functionality as the Golang built-in "template"
function, but returns the produced template string as the return value,
allowing you to pipe the value to another template function.

example:

```yaml
{{ define "foobar" }}
foo:
  bar: baz
{{ end }}

qux:
{{ include "foobar" . | indent 2 }}

# qux:
#   foo:
#     bar: baz
```