### PR TITLE
add "required" template function

### DIFF
--- a/epp/epp.go
+++ b/epp/epp.go
@@ -2,6 +2,7 @@ package epp
 
 import (
 	"bytes"
+	"fmt"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -19,6 +20,17 @@ func Parse(input []byte) ([]byte, error) {
 				return "", err
 			}
 			return buf.String(), nil
+		},
+
+		"required": func(warn string, val interface{}) (interface{}, error) {
+			if val == nil {
+				return val, fmt.Errorf(warn)
+			} else if _, ok := val.(string); ok {
+				if val == "" {
+					return val, fmt.Errorf(warn)
+				}
+			}
+			return val, nil
 		},
 	}
 

--- a/epp/epp_test.go
+++ b/epp/epp_test.go
@@ -3,6 +3,7 @@ package epp
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -63,5 +64,33 @@ hello WORLD`
 
 	if string(res) != expected {
 		t.Errorf("bad expansion: expected '%s', got '%s'", expected, res)
+	}
+}
+
+func TestRequired(t *testing.T) {
+	tpl := []byte(`{{ required "undefined" "hello" }}`)
+	expected := `hello`
+
+	res, err := Parse(tpl)
+
+	if err != nil {
+		t.Errorf("unexpected error '%s'", err)
+	}
+
+	if string(res) != expected {
+		t.Errorf("bad expansion: expected '%s', got '%s'", expected, res)
+	}
+}
+
+func TestRequired_Undefined(t *testing.T) {
+	tpl := []byte(`{{ required "undefined" .Undefined }}`)
+	_, err := Parse(tpl)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "error calling required: undefined") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
This equals the templating function used in Helm.

It provides a way to "require" a specific value to exist, or otherwise
exit the execution of the template parsing.

This can be useful when expecting an environment variable, and not
accepting an empty string as value.

Example:

```yaml
password: {{ required "we really need this!" (env "SECRET_PASSWORD") }}
```