### PR TITLE
Add support to load additional files

### DIFF
--- a/epp.go
+++ b/epp.go
@@ -18,6 +18,7 @@ var (
 
 	output  = flag.String("o", "", "output file")
 	version = flag.Bool("version", false, "print epp version")
+	partialsDir = flag.String("partials-dir", epp.DefaultPartialsPath, "pass the path to your partials directory")
 )
 
 func main() {
@@ -39,7 +40,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	out, err := epp.Parse(fileContents)
+	out, err := epp.Parse(fileContents, *partialsDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "templating error: %s\n", err)
 		os.Exit(1)

--- a/epp/epp_test.go
+++ b/epp/epp_test.go
@@ -17,7 +17,7 @@ func TestEnvVariables(t *testing.T) {
 	tpl := []byte(`{{ env "SPLIT_TEST" }}: {{ env "KUBERNETES_ADDRESS" }}`)
 	expected := fmt.Sprintf("%s: %s", os.Getenv("SPLIT_TEST"), os.Getenv("KUBERNETES_ADDRESS"))
 
-	res, err := Parse(tpl)
+	res, err := Parse(tpl, "")
 
 	if err != nil {
 		t.Errorf("unexpected error '%s'", err)
@@ -39,7 +39,7 @@ I should!
 I should!
 `
 
-	res, err := Parse(tpl)
+	res, err := Parse(tpl, "")
 
 	if err != nil {
 		t.Errorf("unexpected error '%s'", err)
@@ -56,7 +56,7 @@ hello {{ include "worldtpl" . | upper }}`)
 	expected := `
 hello WORLD`
 
-	res, err := Parse(tpl)
+	res, err := Parse(tpl, "")
 
 	if err != nil {
 		t.Errorf("unexpected error '%s'", err)
@@ -71,7 +71,7 @@ func TestRequired(t *testing.T) {
 	tpl := []byte(`{{ required "undefined" "hello" }}`)
 	expected := `hello`
 
-	res, err := Parse(tpl)
+	res, err := Parse(tpl, "")
 
 	if err != nil {
 		t.Errorf("unexpected error '%s'", err)
@@ -84,7 +84,7 @@ func TestRequired(t *testing.T) {
 
 func TestRequired_Undefined(t *testing.T) {
 	tpl := []byte(`{{ required "undefined" .Undefined }}`)
-	_, err := Parse(tpl)
+	_, err := Parse(tpl, "")
 
 	if err == nil {
 		t.Fatalf("expected error, got nil")
@@ -99,7 +99,22 @@ func TestStringList(t *testing.T) {
 	tpl := []byte(`{{ splitList " " "hello world" | last }}`)
 	expected := `world`
 
-	res, err := Parse(tpl)
+	res, err := Parse(tpl, "")
+
+	if err != nil {
+		t.Errorf("unexpected error '%s'", err)
+	}
+
+	if string(res) != expected {
+		t.Errorf("bad expansion: expected '%s', got '%s'", expected, res)
+	}
+}
+
+func TestPartialDir(t *testing.T) {
+	tpl := []byte(`{{ include "hello_partial" . }},{{ include "world_partial" . }}`)
+	expected := `Hello,world`
+
+	res, err := Parse(tpl, "../resources")
 
 	if err != nil {
 		t.Errorf("unexpected error '%s'", err)

--- a/resources/nested/hello_partial.tmpl
+++ b/resources/nested/hello_partial.tmpl
@@ -1,0 +1,3 @@
+{{ define "hello_partial" -}}
+Hello
+{{- end }}

--- a/resources/world_partial.tmpl
+++ b/resources/world_partial.tmpl
@@ -1,0 +1,3 @@
+{{ define "world_partial" -}}
+world
+{{- end }}


### PR DESCRIPTION
This is a backwards compatible change which allows us to load an
additional directory of partials like we do with kubecrt.
We can't concat the files all together since the template `Parse` method
will filter out all the define blocks